### PR TITLE
Replace try! with throwing test methods

### DIFF
--- a/EssentialFeedTests/Feed Cache/CoreDataFeedStoreTests.swift
+++ b/EssentialFeedTests/Feed Cache/CoreDataFeedStoreTests.swift
@@ -8,84 +8,84 @@ import EssentialFeed
 
 class CoreDataFeedStoreTests: XCTestCase, FeedStoreSpecs {
     
-    func test_retrieve_deliversEmptyOnEmptyCache() {
-        let sut = makeSUT()
+    func test_retrieve_deliversEmptyOnEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
     }
     
-    func test_retrieve_hasNoSideEffectsOnEmptyCache() {
-        let sut = makeSUT()
+    func test_retrieve_hasNoSideEffectsOnEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
     }
     
-    func test_retrieve_deliversFoundValuesOnNonEmptyCache() {
-        let sut = makeSUT()
+    func test_retrieve_deliversFoundValuesOnNonEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
     }
     
-    func test_retrieve_hasNoSideEffectsOnNonEmptyCache() {
-        let sut = makeSUT()
+    func test_retrieve_hasNoSideEffectsOnNonEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
     }
     
-    func test_insert_deliversNoErrorOnEmptyCache() {
-        let sut = makeSUT()
+    func test_insert_deliversNoErrorOnEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
     }
     
-    func test_insert_deliversNoErrorOnNonEmptyCache() {
-        let sut = makeSUT()
+    func test_insert_deliversNoErrorOnNonEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
     }
     
-    func test_insert_overridesPreviouslyInsertedCacheValues() {
-        let sut = makeSUT()
+    func test_insert_overridesPreviouslyInsertedCacheValues() throws {
+        let sut = try makeSUT()
         
         assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
     }
     
-    func test_delete_deliversNoErrorOnEmptyCache() {
-        let sut = makeSUT()
+    func test_delete_deliversNoErrorOnEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
     }
     
-    func test_delete_hasNoSideEffectsOnEmptyCache() {
-        let sut = makeSUT()
+    func test_delete_hasNoSideEffectsOnEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
     }
     
-    func test_delete_deliversNoErrorOnNonEmptyCache() {
-        let sut = makeSUT()
+    func test_delete_deliversNoErrorOnNonEmptyCache() throws {
+        let sut = try makeSUT()
         
         assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
     }
     
-    func test_delete_emptiesPreviouslyInsertedCache() {
-        let sut = makeSUT()
+    func test_delete_emptiesPreviouslyInsertedCache() throws {
+        let sut = try makeSUT()
         
         assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
     }
     
-    func test_storeSideEffects_runSerially() {
-        let sut = makeSUT()
+    func test_storeSideEffects_runSerially() throws {
+        let sut = try makeSUT()
         
         assertThatSideEffectsRunSerially(on: sut)
     }
     
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> FeedStore {
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) throws -> FeedStore {
         let storeBundle = Bundle(for: CoreDataFeedStore.self)
         let storeURL = URL(fileURLWithPath: "/dev/null")
-        let sut = try! CoreDataFeedStore(storeURL: storeURL, bundle: storeBundle)
+        let sut = try CoreDataFeedStore(storeURL: storeURL, bundle: storeBundle)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
     }

--- a/EssentialFeedTests/Feed Cache/FeedStoreSpecs/FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/FeedStoreSpecs/FeedStoreSpecs.swift
@@ -6,36 +6,36 @@
 import Foundation
 
 protocol FeedStoreSpecs {
-    func test_retrieve_deliversEmptyOnEmptyCache()
-    func test_retrieve_hasNoSideEffectsOnEmptyCache()
-    func test_retrieve_deliversFoundValuesOnNonEmptyCache()
-    func test_retrieve_hasNoSideEffectsOnNonEmptyCache()
+    func test_retrieve_deliversEmptyOnEmptyCache() throws
+    func test_retrieve_hasNoSideEffectsOnEmptyCache() throws
+    func test_retrieve_deliversFoundValuesOnNonEmptyCache() throws
+    func test_retrieve_hasNoSideEffectsOnNonEmptyCache() throws
     
-    func test_insert_deliversNoErrorOnEmptyCache()
-    func test_insert_deliversNoErrorOnNonEmptyCache()
-    func test_insert_overridesPreviouslyInsertedCacheValues()
+    func test_insert_deliversNoErrorOnEmptyCache() throws
+    func test_insert_deliversNoErrorOnNonEmptyCache() throws
+    func test_insert_overridesPreviouslyInsertedCacheValues() throws
     
-    func test_delete_deliversNoErrorOnEmptyCache()
-    func test_delete_hasNoSideEffectsOnEmptyCache()
-    func test_delete_deliversNoErrorOnNonEmptyCache()
-    func test_delete_emptiesPreviouslyInsertedCache()
+    func test_delete_deliversNoErrorOnEmptyCache() throws
+    func test_delete_hasNoSideEffectsOnEmptyCache() throws
+    func test_delete_deliversNoErrorOnNonEmptyCache() throws
+    func test_delete_emptiesPreviouslyInsertedCache() throws
     
-    func test_storeSideEffects_runSerially()
+    func test_storeSideEffects_runSerially() throws
 }
 
 protocol FailableRetrieveFeedStoreSpecs: FeedStoreSpecs {
-    func test_retrieve_deliversFailureOnRetrievalError()
-    func test_retrieve_hasNoSideEffectsOnFailure()
+    func test_retrieve_deliversFailureOnRetrievalError() throws
+    func test_retrieve_hasNoSideEffectsOnFailure() throws
 }
 
 protocol FailableInsertFeedStoreSpecs: FeedStoreSpecs {
-    func test_insert_deliversErrorOnInsertionError()
-    func test_insert_hasNoSideEffectsOnInsertionError()
+    func test_insert_deliversErrorOnInsertionError() throws
+    func test_insert_hasNoSideEffectsOnInsertionError() throws
 }
 
 protocol FailableDeleteFeedStoreSpecs: FeedStoreSpecs {
-    func test_delete_deliversErrorOnDeletionError()
-    func test_delete_hasNoSideEffectsOnDeletionError()
+    func test_delete_deliversErrorOnDeletionError() throws
+    func test_delete_hasNoSideEffectsOnDeletionError() throws
 }
 
 typealias FailableFeedStoreSpecs = FailableRetrieveFeedStoreSpecs & FailableInsertFeedStoreSpecs & FailableDeleteFeedStoreSpecs


### PR DESCRIPTION
Replace try! with throwing test methods, `try!` can cause crashes, which stops the test execution. When possible, it's best to throw errors in test methods, so you get a failing test rather than a crash.