### PR TITLE
Fix for iOS 15+ cell lifecycle changes

### DIFF
--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -20,6 +20,9 @@ final class FeedImageCellController: FeedImageView {
     
     func view(in tableView: UITableView) -> UITableViewCell {
         cell = tableView.dequeueReusableCell()
+        cell?.onReuse = { [weak self] in
+            self?.releaseCellForReuse()
+        }
         delegate.didRequestImage()
         return cell!
     }

--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -47,6 +47,7 @@ final class FeedImageCellController: FeedImageView {
     }
     
     private func releaseCellForReuse() {
+        cell?.onReuse = nil
         cell = nil
     }
 }

--- a/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
+++ b/EssentialFeediOS/Feed UI/Views/FeedImageCell.swift
@@ -14,8 +14,15 @@ public final class FeedImageCell: UITableViewCell {
     @IBOutlet private(set) public var descriptionLabel: UILabel!
     
     var onRetry: (() -> Void)?
+    var onReuse: (() -> Void)?
     
     @IBAction private func retryButtonTapped() {
         onRetry?()
+    }
+    
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        onReuse?()
     }
 }

--- a/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
@@ -236,6 +236,20 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected second cancelled image URL request once second image is not near visible anymore")
     }
     
+    func test_feedImageView_doesNotShowDataFromPreviousRequestWhenCellIsReused() throws {
+        let (sut, loader) = makeSUT()
+        
+        sut.simulateAppearance()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+        
+        let view = try XCTUnwrap(sut.simulateFeedImageViewVisible(at: 0))
+        view.prepareForReuse()
+        
+        loader.completeImageLoading(with: anyImageData(), at: 0)
+        
+        XCTAssertEqual(view.renderedImage, .none, "Expected no image state change for reused view once image loading completes successfully")
+    }
+    
     func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
         let (sut, loader) = makeSUT()
         

--- a/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
+++ b/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
@@ -250,6 +250,22 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertEqual(view.renderedImage, .none, "Expected no image state change for reused view once image loading completes successfully")
     }
     
+    func test_feedImageView_showsDataForNewViewRequestAfterPreviousViewIsReused() throws {
+        let (sut, loader) = makeSUT()
+        
+        sut.simulateAppearance()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+        
+        let previousView = try XCTUnwrap(sut.simulateFeedImageViewNotVisible(at: 0))
+        let newView = try XCTUnwrap(sut.simulateFeedImageViewVisible(at: 0))
+        previousView.prepareForReuse()
+        
+        let imageData = anyImageData()
+        loader.completeImageLoading(with: imageData, at: 1)
+        
+        XCTAssertEqual(newView.renderedImage, imageData)
+    }
+    
     func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
         let (sut, loader) = makeSUT()
         


### PR DESCRIPTION
Release cell reference on `prepareForReuse` as a fix for iOS 15+ cell lifecycle changes.

On iOS 15+, for performance reasons, the table view data source may create cells ahead of time using the `cellForRow` method. So the cell may be created but never go through the whole `willDisplayCell/didEndDisplaying` lifecycle callbacks as it may never be displayed.

However, we start loading the cell image on `cellForRow` and only cancel the request on `didEndDisplaying`. In such cases, there can be a race condition when reusing a cell that was never displayed because the request would carry on and potentially load the wrong image at the wrong index path.

Ensure previous cells' prepareForReuse doesn't affect new cells by removing the onReuse closure reference when releasing the cell for reuse.

Every time we update the table view state, existing cells can be reused for different index paths, where they'll be managed by different cell controllers - so we need to remove all references to the previous cell controllers when releasing the cell for reuse. Since the `onReuse` closure references the cell controller via `self`, we need to set `onReuse` to `nil` when releasing the cell for reuse by another cell controller. This way, we ensure there are no references to the cell controller so there will be no side effects.