### PR TITLE
Update `Core Data` storage setting

### DIFF
--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/FeedStore.xcdatamodeld/FeedStore2.xcdatamodel/contents
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/FeedStore.xcdatamodeld/FeedStore2.xcdatamodel/contents
@@ -5,7 +5,7 @@
         <relationship name="feed" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ManagedFeedImage" inverseName="cache" inverseEntity="ManagedFeedImage"/>
     </entity>
     <entity name="ManagedFeedImage" representedClassName="ManagedFeedImage" syncable="YES">
-        <attribute name="data" optional="YES" attributeType="Binary"/>
+        <attribute name="data" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="imageDescription" optional="YES" attributeType="String"/>
         <attribute name="location" optional="YES" attributeType="String"/>


### PR DESCRIPTION
SQLite (used by Core Data behind the scenes) can handle binary data pretty well, but up to a point. If you are storing large binary data files (e.g., high-resolution images), it’s recommended to store it on disk instead.

Luckily, Core Data gives you this functionality out-of-the-box. You just need to enable the “Allows External Storage” option in your binary data attribute.


> “Allows External Storage […] lets Core Data decide whether it stores binary data within SQLite or as external files, based on the size of the data. The underlying SQLite database can efficiently store binary data up to roughly 100 kilobytes directly in the database. This option should generally be enabled.
>
>Keep in mind that including large binary data in your model objects will make them more expensive to keep in memory. If, in most cases, you need the binary data together with the other attributes in the entity, it makes sense to store them together. Otherwise, it might be worthwhile to store the binary data in a separate entity and create a relationship between the two.
>
>Another alternative is to only store file names in Core Data and manage the storage of the actual data on disk yourself. However, you should have a very good reason to do this instead of just storing the data in Core Data itself. You’re taking on full responsibility to ensure data integrity between Core Data and your own binary storage, which isn’t always an easy task.”—Florian Kugler. “Core Data.”